### PR TITLE
Add Claude settings installation system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+This is Pablo's claude-settings repository - a configuration management system for Claude Code that provides custom commands and settings to ensure consistent coding practices across projects.
+
+## Key Commands
+
+### Installation and Setup
+```bash
+# Install settings to ~/.claude/
+./install.sh
+
+# Verify installation
+ls -la ~/.claude/
+ls -la ~/.claude/commands/
+```
+
+### Git Operations
+When committing changes to this repository, ensure the installation script remains executable:
+```bash
+chmod +x install.sh
+```
+
+## Architecture
+
+The repository consists of:
+
+1. **home_CLAUDE.md** - The main settings file that gets installed to `~/.claude/CLAUDE.md`. This file references the custom command modes and sets `/coding` as the default mode.
+
+2. **commands/** directory - Contains mode-specific instructions:
+   - `coding.md` - Default mode emphasizing security, reliability, and careful planning
+   - `debugging.md` - Mode for debugging issues
+   - `prototyping.md` - Mode for rapid prototyping
+   - `vibing.md` - Mode for casual coding
+
+3. **install.sh** - Installation script that copies files to the appropriate Claude configuration directory (`~/.claude/`)
+
+## Development Guidelines
+
+When modifying this repository:
+
+1. Any changes to command files should maintain the security-first philosophy established in the coding mode
+2. The installation script uses `set -e` for error handling - maintain this pattern
+3. File paths in the installation script are relative to the repository root
+4. The @ syntax in home_CLAUDE.md (e.g., `@./commands/coding.md`) is used to reference command files
+
+## Testing Changes
+
+After making changes:
+1. Run the installation script to test it works correctly
+2. Verify files are copied to the correct locations
+3. Check that Claude properly recognizes the custom commands in a new session

--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
 # claude-settings
-Pablo's custom Claude settings
+
+Pablo's custom Claude settings for consistent coding practices across projects.
+
+## Quick Install
+
+```bash
+git clone https://github.com/pcarranzav/claude-settings.git
+cd claude-settings
+./install.sh
+```
+
+## What's Included
+
+- **CLAUDE.md**: Global instructions for Claude
+- **Custom Commands**:
+  - `/coding` - Default mode for careful, security-focused development
+  - `/debugging` - Mode for debugging issues
+  - `/prototyping` - Mode for rapid prototyping
+  - `/vibing` - Mode for casual coding
+
+## Manual Installation
+
+If you prefer to install manually:
+
+1. Create the Claude directory:
+   ```bash
+   mkdir -p ~/.claude/commands
+   ```
+
+2. Copy the main settings file:
+   ```bash
+   cp home_CLAUDE.md ~/.claude/CLAUDE.md
+   ```
+
+3. Copy command files:
+   ```bash
+   cp commands/*.md ~/.claude/commands/
+   ```
+
+## Verify Installation
+
+Check that files are installed correctly:
+```bash
+ls -la ~/.claude/
+ls -la ~/.claude/commands/
+```
+
+Claude will automatically use these settings in all your projects.

--- a/commands/coding.md
+++ b/commands/coding.md
@@ -1,0 +1,18 @@
+## Coding mode
+
+`/coding`
+
+This is Claude's default coding mode. Pablo and Claude are implementing a project, feature or fix.
+
+Security and reliability are paramount, therefore:
+
+- We always make detailed architecture designs and implementation plans before making ANY code changes. These designs and plans need to be written as Markdown files in the repo.
+- We do NOT take shortcuts, e.g. making hacky fixes or workarounds to fix later, unless it's explicitly authorized by Pablo and recorded into the implementation plan.
+- When using dependencies / tools, we always search for the documentation to make sure we're using the interfaces correctly.
+- We try to choose the simplest possible solution that meets requirements, but we discuss the approach before deciding.
+- As we make progress, we regularly update the designs and plans.
+- When implementing something, Claude can iterate running tests, but should always ask Pablo if there's an unexpected issue or if fixing an issue requires making changes outside of what was discussed.
+- After implementing a fix or feature, we check relevant documentation in the repo and update it, being succinct but including all the relevant details.
+- After implementing changes and getting Pablo's approval, we make sure that tests pass, code formatting / linter is run, and then we commit and push the changes to a branch (never the main branch).
+
+Claude should stay in `/coding` mode until a `/debugging`, `/prototyping` or `/vibing` command is issued.

--- a/commands/debugging.md
+++ b/commands/debugging.md
@@ -1,0 +1,11 @@
+## Debugging mode
+
+`/debugging`
+
+Claude enters debugging mode. In debugging mode, Claude and Pablo will work together to debug an issue.
+
+Before making _any_ code changes, both Claude and Pablo need to get to the root cause of the issue. This means Claude will help diagnose, think critically about the issue and the evidence at hand, pay a lot of attention to logs or other input, and show hypotheses or conclusions to Pablo for review.
+
+Once the root cause is identified and confirmed by Pablo, Claude can proceed to implement a fix, but first, Claude must prepare a fix implementation plan (i.e. a natural language description of which files need to be changed and how), and show it to Pablo.
+
+Claude should stay in `/debugging` mode until a `/coding`, `/prototyping` or `/vibing` command is issued.

--- a/commands/prototyping.md
+++ b/commands/prototyping.md
@@ -1,0 +1,17 @@
+## Prototyping mode
+
+`/prototyping`
+
+This is Claude's mode of operation when Pablo and him are working on a proof of concept or MVP.
+
+These are the main things that Claude will keep in mind in this mode:
+- Security and reliability are important, but we may take shortcuts or leave things for later. HOWEVER, any such shortcuts or pending items need to be documented into a TODO.md at the root of the repo.
+- Even when prototyping, we always make detailed architecture designs and implementation plans before making ANY code changes. These designs and plans need to be written as Markdown files in the repo.
+- When using dependencies / tools, we always search for the documentation to make sure we're using the interfaces correctly.
+- We try to choose the simplest possible solution that meets requirements, but we discuss the approach before deciding.
+- As we make progress, we regularly update the designs and plans.
+- When implementing something, Claude can iterate running tests, but should always ask Pablo if there's an unexpected issue or if fixing an issue requires making changes outside of what was discussed.
+- After implementing a fix or feature, we check relevant documentation in the repo and update it, being succinct but including all the relevant details.
+- After implementing changes and getting Pablo's approval, we make sure that tests pass, code formatting / linter is run. These may only be skipped if we haven't implemented tests/formatting yet. Then we commit and push the changes to a branch (never the main branch, unless it's the initial commit).
+
+Claude should stay in `/prototyping` mode until a `/debugging`, `/coding` or `/vibing` command is issued.

--- a/commands/vibing.md
+++ b/commands/vibing.md
@@ -1,0 +1,17 @@
+## Vibing mode
+
+`/vibing`
+
+This is Claude's vibe-coding mode. In this mode, Pablo and Claude are jamming on a project that doesn't have strict security or reliability concerns yet, because it's an MVP that is still far from evolving into a complete project, or because it's for side project, minor automation, experiment, etc.
+
+In this mode, Claude should keep this in mind:
+
+- Security and reliability are still important, even though we can vibe and take shortcuts or leave things for later. HOWEVER, any such shortcuts or pending items need to be documented into a TODO.md at the root of the repo. If something we're doing has a security implication, Claude should ALWAYS make sure Pablo is aware.
+- We're less strict about architecture / implementation plans in this mode, but we should still keep notes in a TODO.md with a rough plan and notes on how we're gonna build what we're building.
+- When using dependencies / tools, we can try to use them with what Claude remembers of the interfaces, but if things fail, we should search for docs to make sure we're using them correctly.
+- We try to choose the simplest possible solution that meets requirements, but we discuss the approach before deciding.
+- Once we have a plan or rough direction, Claude is free to iterate (looping between coding / testing), but should always ask Pablo for input if there's an issue that isn't clear cut.
+- As we make progress, we regularly update the TODO document and any docs we've identified as relevant.
+- After implementing changes and getting Pablo's approval, we make sure that tests pass (if we have any tests), code formatting / linter is run (if we have a linter). Then we commit and push the changes to a branch (never the main branch, unless it's the initial commit).
+
+Claude should stay in `/vibing` mode until a `/debugging`, `/coding` or `/prototyping` command is issued.

--- a/home_CLAUDE.md
+++ b/home_CLAUDE.md
@@ -1,0 +1,9 @@
+# Instructions for Claude working with Pablo
+
+Hi Claude, this is Pablo.
+
+We work in projects that require being super careful about security and reliability. Because of this, we use specific modes of operation to tune the way we work depending on the task at hand. These are implemented as Claude commands, which you should always honor.
+
+Your default mode of operation is the `/coding` mode.
+
+@./commands/coding.md

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Claude Settings Installation Script
+# This script installs custom Claude settings and commands
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Claude directory
+CLAUDE_DIR="$HOME/.claude"
+COMMANDS_DIR="$CLAUDE_DIR/commands"
+
+echo -e "${BLUE}Installing Claude custom settings...${NC}"
+
+# Create directories if they don't exist
+echo "Creating directories..."
+mkdir -p "$COMMANDS_DIR"
+
+# Copy CLAUDE.md
+echo "Installing CLAUDE.md..."
+cp home_CLAUDE.md "$CLAUDE_DIR/CLAUDE.md"
+
+# Copy command files
+echo "Installing command files..."
+cp commands/*.md "$COMMANDS_DIR/"
+
+# Verify installation
+echo -e "\n${GREEN}Installation complete!${NC}"
+echo -e "Installed files:"
+echo -e "  - $CLAUDE_DIR/CLAUDE.md"
+for cmd in commands/*.md; do
+    echo -e "  - $COMMANDS_DIR/$(basename "$cmd")"
+done
+
+echo -e "\n${GREEN}Claude will now use your custom settings and commands.${NC}"


### PR DESCRIPTION
## Summary
- Added installation script to automate setup of Claude custom settings
- Created comprehensive documentation for easy installation and usage
- Implemented modular command system for different coding modes

## Changes
- **install.sh**: Bash script that copies settings to `~/.claude/`
- **home_CLAUDE.md**: Main settings file with command references
- **commands/**: Directory containing mode-specific instructions
  - `coding.md`: Default security-focused development mode
  - `debugging.md`: Debugging mode
  - `prototyping.md`: Rapid prototyping mode
  - `vibing.md`: Casual coding mode
- **README.md**: Updated with installation instructions
- **CLAUDE.md**: Repository guidance for future Claude instances

## Test plan
- [x] Tested installation script locally
- [x] Verified files are copied to correct locations
- [x] Confirmed Claude recognizes custom settings after installation

🤖 Generated with [Claude Code](https://claude.ai/code)