### PR TITLE
Update README to use SSH for git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Pablo's custom Claude settings for consistent coding practices across projects.
 ## Quick Install
 
 ```bash
-git clone https://github.com/pcarranzav/claude-settings.git
+git clone git@github.com:pcarranzav/claude-settings.git
 cd claude-settings
 ./install.sh
 ```


### PR DESCRIPTION
## Summary
- Updated the installation instructions in README.md to use SSH format for cloning the repository

## Test plan
- [x] Verify the SSH clone command is correctly formatted
- [ ] Test cloning with the new SSH URL (requires SSH keys configured)

🤖 Generated with [Claude Code](https://claude.ai/code)